### PR TITLE
Add Multisampling for Bootstrap, Subset and Placebo Refuters (#113)

### DIFF
--- a/dowhy/causal_refuters/bootstrap_refuter.py
+++ b/dowhy/causal_refuters/bootstrap_refuter.py
@@ -6,10 +6,10 @@ import logging
 class BootstrapRefuter(CausalRefuter):
     """
     Refute an estimate by running it on a random sample of the original data.
-    It supports additional parameters that can be specified in the regute_estimate() method.
-    - 'number_of_samples': int, None by default
-    The number of bootstrap samples to be constructed
-    - 'sample_size': int, None by default
+    It supports additional parameters that can be specified in the refute_estimate() method.
+    - 'num_simulations': int, 200 by default
+    The number of bootstrap simulations to be run
+    - 'sample_size': int, Size of the original data by default
     The size of each bootstrap sample
     - 'random_state': int, RandomState, None by default
     The seed value to be added if we wish to repeat the same random behavior. For this purpose, 
@@ -18,7 +18,7 @@ class BootstrapRefuter(CausalRefuter):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._number_of_samples = kwargs.pop("number_of_samples", 200)
+        self._num_simulations = kwargs.pop("num_simulations", 200)
         self._sample_size = kwargs.pop("sample_size",len(self._data))
         self._random_state = kwargs.pop("random_state",None)
 
@@ -32,9 +32,13 @@ class BootstrapRefuter(CausalRefuter):
         if self._sample_size > len(self._data):
                 self.logger.warning("The sample size is larger than the population size")
 
-        sample_estimates = np.zeros(self._number_of_samples) 
+        sample_estimates = np.zeros(self._num_simulations)
+        self.logger.info("Refutation over {} simulated datasets of size {} each"
+                         .format(self._num_simulations
+                         ,self._sample_size )
+                        ) 
         
-        for index in range( self._number_of_samples ):
+        for index in range(self._num_simulations):
             if self._random_state is None:
                 new_data = resample(self._data, 
                                 n_samples=self._sample_size )

--- a/dowhy/causal_refuters/data_subset_refuter.py
+++ b/dowhy/causal_refuters/data_subset_refuter.py
@@ -1,28 +1,55 @@
 from dowhy.causal_refuter import CausalRefuter, CausalRefutation
-
+import numpy as np
+import logging
 
 class DataSubsetRefuter(CausalRefuter):
     """Refute an estimate by rerunning it on a random subset of the original data.
 
     Supports additional parameters that can be specified in the refute_estimate() method.
 
-    - 'subset_fraction': Fraction of the data to be used for re-estimation.
-
+    - 'subset_fraction': float, 0.8 by default
+    Fraction of the data to be used for re-estimation.
+    - 'num_simulations': int, 200 by default
+    The number of simulations to be run
+    - random_state': int, RandomState, None by default
+    The seed value to be added if we wish to repeat the same random behavior. If we with to repeat the
+    same behavior we push the same seed in the psuedo-random generator
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._subset_fraction = kwargs["subset_fraction"]
+        self._subset_fraction = kwargs.pop("subset_fraction", 0.8)
+        self._num_simulations = kwargs.pop("num_simulations", 200)
+        self._random_state = kwargs.pop("random_state",None)
+
+        if 'logging_level' in kwargs:
+            logging.basicConfig(level=kwargs['logging_level'])
+        else:
+            logging.basicConfig(level=logging.INFO)
+        self.logger = logging.getLogger(__name__)
 
     def refute_estimate(self):
-        new_data = self._data.sample(frac=self._subset_fraction)
 
-        new_estimator = self.get_estimator_object(new_data, self._target_estimand, self._estimate)
-        new_effect = new_estimator.estimate_effect()
+        sample_estimates = np.zeros(self._num_simulations)
+        self.logger.info("Refutation over {} simulated datasets of size {} each"
+                         .format(self._subset_fraction
+                         ,self._subset_fraction*len(self._data.index) )
+                        )
+
+        for index in range(self._num_simulations):
+            if self._random_state is None:
+                new_data = self._data.sample(frac=self._subset_fraction)
+            else:
+                new_data = self._data.sample(frac=self._subset_fraction,
+                                            random_state=self._random_state)
+                                            
+            new_estimator = self.get_estimator_object(new_data, self._target_estimand, self._estimate)
+            new_effect = new_estimator.estimate_effect()
+            sample_estimates[index] = new_effect.value
 
         refute = CausalRefutation(
             self._estimate.value,
-            new_effect.value,
+            np.mean(sample_estimates),
             refutation_type="Refute: Use a subset of data"
         )
         return refute

--- a/dowhy/causal_refuters/placebo_treatment_refuter.py
+++ b/dowhy/causal_refuters/placebo_treatment_refuter.py
@@ -11,28 +11,62 @@ class PlaceboTreatmentRefuter(CausalRefuter):
 
     Supports additional parameters that can be specified in the refute_estimate() method.
 
-    - '_placebo_type': Default is to generate random values for the treatment. If placebo_type is "permute", then the original treatment values are permuted by row.
-
+    - 'placebo_type':  str, None by default
+    Default is to generate random values for the treatment. If placebo_type is "permute", 
+    then the original treatment values are permuted by row.
+    - 'num_simulations': int, 200 by default
+    The number of simulations to be run
+    - 'random_state': int, RandomState, None by default
+    The seed value to be added if we wish to repeat the same random behavior. If we with to repeat the
+    same behavior we push the same seed in the psuedo-random generator
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._placebo_type = kwargs["placebo_type"]
+        self._placebo_type = kwargs.pop("placebo_type",None)
+        if self._placebo_type is None:
+            self._placebo_type = "Random Data"
+        self._num_simulations = kwargs.pop("num_simulations",200)
+        self._random_state = kwargs.pop("random_state",None)
 
     def refute_estimate(self):
-        num_rows = self._data.shape[0]
-        if self._placebo_type == "permute":
-            new_treatment = self._data[self._treatment_name].sample(frac=1).values
-        else:
-            new_treatment = np.random.randn(num_rows)
-        new_data = self._data.assign(placebo=new_treatment)
 
-        self.logger.debug(new_data[0:10])
-        estimator_class = self._estimate.params['estimator_class']
+        # We need to change the identified estimand
+        # This is done as a safety measure, we don't want to change the
+        # original DataFrame
         identified_estimand = copy.deepcopy(self._target_estimand)
         identified_estimand.treatment_variable = ["placebo"]
 
-        new_estimator = self.get_estimator_object(new_data, identified_estimand, self._estimate)
-        new_effect = new_estimator.estimate_effect()
-        refute = CausalRefutation(self._estimate.value, new_effect.value,
+        sample_estimates = np.zeros(self._num_simulations)
+        self.logger.info("Refutation over {} simulated datasets of {} treatment"
+                        .format(self._num_simulations
+                        ,self._placebo_type)
+                        )
+
+        num_rows = self._data.shape[0]
+
+        for index in range(self._num_simulations):
+
+            if self._placebo_type == "permute":
+                if self._random_state is None:
+                    new_treatment = self._data[self._treatment_name].sample(frac=1).values
+                else:
+                    new_treatment = self._data[self._treatment_name].sample(frac=1, 
+                                                                    random_state=self._random_state).values                    
+            else:
+                new_treatment = np.random.randn(num_rows)
+            
+            # Create a new column in the data by the name of placebo
+            new_data = self._data.assign(placebo=new_treatment)
+
+            # Sanity check the data
+            self.logger.debug(new_data[0:10])
+
+            
+            new_estimator = self.get_estimator_object(new_data, identified_estimand, self._estimate)
+            new_effect = new_estimator.estimate_effect()
+            sample_estimates[index] = new_effect.value
+
+        refute = CausalRefutation(self._estimate.value, 
+                                  np.mean(sample_estimates),
                                   refutation_type="Refute: Use a Placebo Treatment")
         return refute


### PR DESCRIPTION
* Add bootstrap refuter

* Update documentation and add return type

* fix missing function call

* Add missing import

* remove unecessary indent

* refactor code to accomodate multiple samples

* fix mismatch in number_of_samples and sample_size

* fix indent error

* Add documentation for sample_size

* Create multiple samples for Subset Refuter

The user can now run the subset refuter multiple times, so as to help generate confidance intervals for the value of the refuter obtained.
 The list of changes include:
- Add logging
- Add RandomState
- Create Array of Refutations
- Update inline documentation to reflect changes

* Add info log of params

* Add random state to subset refuter

* remove redundant assignment

* Create multiple samples for Placebo Refuter

    The user can now run the subset refuter multiple times, so as to help generate confidance intervals for the value of the refuter obtained.
     The list of changes include:
    - Add logging
    - Add RandomState
    - Create Array of Refutations
    - Update inline documentation to reflect changes

* Create multiple samples for Placebo Refuter

    The user can now run the placebo refuter multiple times, so as to help generate confidance intervals for the value of the refuter obtained.
     The list of changes include:
    - Add logging
    - Add RandomState
    - Create Array of Refutations
    - Update inline documentation to reflect changes

* Add info of samples and treatment

* replace number_of_samples to num_of_simulations to maintain consistancy of notation

* Change documentation to reflect functionality in bootstrap refuter

* Change the inline documentation to reflect the defaults used in the implementation

* remove redundant whitespaces in for loops

* make info messages verbose

* change num_of_simulations to num_simulations